### PR TITLE
store edits to question text and notes

### DIFF
--- a/client/controllers.js
+++ b/client/controllers.js
@@ -62,11 +62,11 @@ function($scope, $state, $meteorCollection, $meteorSubscribe){
             event.target.value = '';
         }
     }
-    
+
     $scope.checkState = function(name){
         return $state.current.name == name;
     }
-    
+
 }]);
 
 
@@ -76,9 +76,9 @@ function($scope, $state, $meteorCollection, $meteorSubscribe){
 // see _OLD DatasetController
 // ***********************************
 
-angular.module('dataFramer').controller('QuestionIndexController', ['$scope','$meteorCollection', 
+angular.module('dataFramer').controller('QuestionIndexController', ['$scope','$meteorCollection',
     '$stateParams', '$meteorSubscribe', '$state', '$meteorObject', '$rootScope', '$meteorUtils',
-    function($scope, $meteorCollection, $stateParams, $meteorSubscribe, 
+    function($scope, $meteorCollection, $stateParams, $meteorSubscribe,
         $state, $meteorObject, $rootScope, $meteorUtils){
 
         $meteorSubscribe.subscribe('columns', $stateParams.datasetId);
@@ -89,32 +89,9 @@ angular.module('dataFramer').controller('QuestionIndexController', ['$scope','$m
             $scope.questions = $meteorCollection(function(){
                 return Questions.find({dataset_id:$stateParams.datasetId});
             });
-            $scope.question = $meteorObject(Questions, $stateParams.questionId);
-
-            $scope.isSet = function(ans_value){
-                // if answerable state isn't set, fade the button
-                if ($scope.question.answerable != ans_value) {
-                    return "fade";
-                }
-            };
-
-            // $scope.setAns = function(ans_value){
-            //     $scope.question.answerable = ans_value;
-            //     // TODO: this probably doesn't work
-            // };
-
-            $scope.remove = function(col){
-                alert("Are you sure you want to remove this question?");
-                $scope.question.col_refs = _.without($scope.question.col_refs, col._id);
-                $scope.question.save();
-                $scope.columns = $meteorCollection(function(){
-                    return Columns.find({_id: {$in: $scope.question.col_refs}});
-                });
-            }
-
         });
 
-        $scope.sections = 
+        $scope.sections =
            [{'name': 'Keep', 'answerable': true },
             {'name': 'Undecided' , 'answerable': null },
             {'name': 'Reject', 'answerable': false }];
@@ -130,27 +107,6 @@ angular.module('dataFramer').controller('QuestionIndexController', ['$scope','$m
 
         $scope.checkState = function(name){
             return $state.current.name == name;
-        };
-
-        $scope.varNames = function(){
-            $scope.vars = $meteorCollection(function(){
-                return Columns.find({_id: {$in: $scope.question.col_refs}});
-            });
-        };
-
-        $scope.isSet = function(ans_value){
-            // if answerable state isn't set, fade the button
-            if ($scope.question.answerable != ans_value) {
-                return "fade";
-            }
-        };
-
-        $scope.remove = function(col){
-            $scope.question.col_refs = _.without($scope.question.col_refs, col._id);
-            $scope.question.save();
-            $scope.columns = $meteorCollection(function(){
-                return Columns.find({_id: {$in: $scope.question.col_refs}});
-            });
         };
 
         $scope.addQuestion = function(text){
@@ -203,28 +159,31 @@ angular.module('dataFramer').controller('QuestionIndexController', ['$scope','$m
             return ''
         }
 
-        document.addEventListener('keydown', function (event) {
-          var esc = event.which == 27,
-              nl = event.which == 13,
-              el = event.target,
-              input = el.nodeName != 'INPUT' && el.nodeName != 'TEXTAREA'
-              // data = {};
+        $scope.editQuestion = function(event, q_id){
+            var esc = event.which == 27,
+                nl = event.which == 13,
+                el = event.target,
+                input = el.nodeName != 'INPUT' && el.nodeName != 'TEXTAREA'
+                ;
 
-          if (input) {
-            if (esc) {
-              // restore state
-              document.execCommand('undo');
-              el.blur();
-            } else if (nl) {
-
-                //TODO: $scope seems to only save it in current veiw.. probably need to save text and notes separately
-                Questions.update({ _id: $scope.question._id }, { $set: { text: el.innerHTML, notes: el.innerHTML } });
-
-                el.blur();
-                event.preventDefault();
+            if (input) {
+                if (esc) {
+                  // restore state
+                  document.execCommand('undo');
+                  el.blur();
+                } else if (nl) {
+                    // are we editing the question or the notes?
+                    if (el.classList.contains('question-card-text')) {
+                        Questions.update({ _id: q_id }, { $set: { text: el.innerHTML} });
+                    } else if (el.classList.contains('question-card-notes')) {
+                        Questions.update({ _id: q_id }, { $set: { notes: el.innerHTML} });
+                    }
+                    el.blur();
+                    event.preventDefault();
+                }
             }
-          }
-        }, true);
+        }
+
 
 }]);
 
@@ -253,7 +212,7 @@ function($scope, $state, $window, $stateParams, $meteorSubscribe, $meteorCollect
         $scope.$emit('datasetReady');
         $scope.dataset = $meteorObject(Datasets, $stateParams.datasetId);
     });
-        
+
     $meteorSubscribe.subscribe('columns', $stateParams.datasetId)
     .then(function(sub){
         $scope.columns = $meteorCollection(function(){
@@ -262,17 +221,17 @@ function($scope, $state, $window, $stateParams, $meteorSubscribe, $meteorCollect
         $scope.$emit('colsReady');
         $scope.chartsReady = true;
     });
-            
+
     $scope.datatypes = DATATYPE_LIST;
 
     $scope.checkState = function(name){
         return $state.current.name == name;
     }
-        
+
     $scope.varClick = function(col){
        $window.scroll(0,$('#'+col._id).offset().top);
     };
-    
+
     $scope.changeType = changeType;
 
 }]);

--- a/client/templates/question-index.tpl
+++ b/client/templates/question-index.tpl
@@ -2,7 +2,7 @@
 
      <div id="question-wrapper">
      	<h2 id="q-list-title">My Questions</h2>
-      
+
       	<div class="row">
 		    <div ng-repeat= "section in sections" class="col-md-4 question-bin">
 		    	<span class="q-section-name">{{ section.name }}</span>
@@ -13,24 +13,23 @@
 			                <span ng-class="answerable(question._id)">
 			                    <i class="fa ng-class:answerableIcon(question._id);"></i>
 			                </span>
-			                <a class="question-card-text" contenteditable>
+			                <span class="question-card-text question-editable" contenteditable ng-keypress="editQuestion($event, question._id)">
 			                    {{ question.text }}
-
-			                </a>
+			                </span>
 			                <div ng-if="question.col_refs.length > 0">
 				                <ul class="vars-on-q">
 				                	<li class="var-pill label" ng-repeat ="var in question.col_refs" type="var.type">
 				                		{{ getVarName(var) }}
 				                	</li>
 				                </ul>
-				            </div>    
-			                
-			              
+				            </div>
+
+
 			                <div>
 			                	<hr class="q-notes-divider">
 			                	<span class="q-notes-label">Notes: </span>
-			                	<small class="notes-section"><a class="question-card-text text-muted" contenteditable>{{ question.notes }}</a></small>
-			                	
+			                	<small class="notes-section"><span class="question-card-notes question-editable text-muted" contenteditable ng-keypress="editQuestion($event, question._id)" data-placeholder="Click to add...">{{ question.notes }}</span></small>
+
 			            	</div>
 
 			            	<div class="row q-icon-row">
@@ -38,7 +37,7 @@
 		            			<span class="pull-right" tooltip="Delete this question" tooltip-placement="bottom" tooltip-append-to-body="true" ng-confirm-click="Are you sure you would like to delete this question?: \n\n{{question.text}}" confirmed-click="deleteQuestion()" >
 				                    <i class="fa fa-trash-o"></i>
 				                </span>
-				            	
+
 	               				<span class="dropdown pull-right control q-list-dropdown">
 					            <a data-toggle="dropdown" tooltip="Move to different bin" tooltip-placement="bottom" tooltip-append-to-body="true">
 					                <i class="fa fa-exchange"><span class="caret"></span></i>
@@ -58,9 +57,9 @@
 				                		<i class="fa fa-bar-chart"></i>
 				                	</a>
 	               				</span>
-			            		
+
 			            	</div>
-			            	
+
 		                </div>
 		            </li>
 		        </ul>
@@ -85,4 +84,3 @@
         </form>
 
     </div>
-

--- a/style/style.less
+++ b/style/style.less
@@ -109,16 +109,20 @@ ul.questions-list {
     }
 }
 
-.question-card-text {
-    color: black;
+.question-editable {
+    // color: black;
     position: relative;
 }
 
-.question-card-text:hover {
+.question-editable:hover {
     background-color: #e3e3e3;
     color: black;
 }
 
+.question-editable:empty:not(:focus):before{
+        content:attr(data-placeholder);
+        font-style: italic;
+    }
 
 .q-list-dropdown {
     margin-left: 10px;


### PR DESCRIPTION
@annaswigart please review

commit summary: 

question text and notes saving works
- use classes to distinguish between notes and text and update DB
accordingly
- use ng-keypress instead of attaching listener to document, so we can
pass the question id
- use a CSS trick to show placeholder text for an empty note, making it
discoverable and clickable
- remove some references to $scope.question that weren’t doing anything
because $scope.question doesn’t exist
- fixes #48, fixes #49