### PR TITLE
Fixes some bugs in the chart rendering of certain columns.

### DIFF
--- a/client/charts-directive.js
+++ b/client/charts-directive.js
@@ -340,16 +340,23 @@ var renderTimeChart = function(scope, dimensions) {
   var groups = _.groupBy(data.values, function(d) {
     if (d != null) {
       d = format.parse(d);
-      return d.getHours(); }
-    });
+      return d.getHours();
+    }
+  });
   var max = _.max(_.map(_.values(groups), function(x) {
-    return x.length; }));
+    return x.length; 
+  }));
 
   y.domain([0, max]);
-  var histogram = _.map(bins, function(x) {
+  var histogram = _.map(bins, function(b) {
+    var itemsInBin = groups[b.getHours()]
+      , f = 0.0;
+    if (!_.isUndefined(itemsInBin)) {
+      f = itemsInBin.length; 
+    }
     return {
-      "bin": x,
-      "frequency": groups[x.getHours()].length
+      "bin": b,
+      "frequency": f
       };
   });
 

--- a/lib/datatypes.js
+++ b/lib/datatypes.js
@@ -1,11 +1,24 @@
 // functions for creating data structures per datatype
 
+formatTime = function(value) {
+  var noColon = value.match(/\d\d\d\d/)
+    , colon = value.match(/\d\d:\d\d/);
+  if (noColon != null) {
+    var d = value.split("");
+    return d[0] + d[1] + ":" + d[2] + d[3];
+  } else if (colon != null) {
+    return value;
+  }
+  console.log("ERROR: Cannot process value as time: ", value);
+}
+
 processTime = function(col) {
     
-    // TODO: Come back to this.
-
-    _.each(col.orig_values, function(v,i){
-        if (!checkNull(v, true)) col.values.push(v);
+    _.each(col.orig_values, function(v,i) {
+        if (!checkNull(v, true)) {
+          v = formatTime(v);
+          col.values.push(v);
+        }
     });
 
     if (col.values.length) {
@@ -14,7 +27,7 @@ processTime = function(col) {
     }
 
     // store count of nulls
-    col.nulls = _.reduce(col.orig_values, function(memo, v){
+    col.nulls = _.reduce(col.orig_values, function(memo, v) {
         return checkNull(v, true)? memo + 1 : memo;
     }, 0);
 
@@ -22,12 +35,12 @@ processTime = function(col) {
 }
 
 processFloat = function(col) {
-    _.each(col.orig_values, function(v,i){
+    _.each(col.orig_values, function(v,i) {
         if (!checkNull(v, true)) col.values.push(parseFloat(v));
     });
     if (col.values.length) {
         // calculate the mean
-        var sum = _.reduce(col.values, function(memo, num){
+        var sum = _.reduce(col.values, function(memo, num) {
             return memo + num
         }, 0);
 
@@ -49,20 +62,20 @@ processFloat = function(col) {
     }
 
     // store count of nulls
-    col.nulls = _.reduce(col.orig_values, function(memo, v){
+    col.nulls = _.reduce(col.orig_values, function(memo, v) {
         return checkNull(v, true)? memo + 1 : memo;
     }, 0);
 
     return col;
 }
 
-processInt = function(col){
-    _.each(col.orig_values, function(v,i){
+processInt = function(col) {
+    _.each(col.orig_values, function(v,i) {
         if (!checkNull(v, true)) col.values.push(parseInt(v));
     });
     if (col.values.length) {
         // calculate the mean
-        var sum = _.reduce(col.values, function(memo, num){
+        var sum = _.reduce(col.values, function(memo, num) {
             return memo + num
         }, 0);
 
@@ -83,7 +96,7 @@ processInt = function(col){
     }
 
     // store count of nulls
-    col.nulls = _.reduce(col.orig_values, function(memo, v){
+    col.nulls = _.reduce(col.orig_values, function(memo, v) {
         return checkNull(v, true)? memo + 1 : memo;
     }, 0);
 
@@ -91,7 +104,7 @@ processInt = function(col){
 }
 
 processString = function(col) {
-    _.each(col.orig_values, function(v,i){
+    _.each(col.orig_values, function(v,i) {
         if (!checkNull(v, true)) col.values.push(v);
     });
 
@@ -101,15 +114,15 @@ processString = function(col) {
     }
 
     // store count of nulls
-    col.nulls = _.reduce(col.orig_values, function(memo, v){
+    col.nulls = _.reduce(col.orig_values, function(memo, v) {
         return checkNull(v, true)? memo + 1 : memo;
     }, 0);
 
     return col;
 }
 
-processDate = function(col){
-    _.each(col.orig_values, function(v){
+processDate = function(col) {
+    _.each(col.orig_values, function(v) {
         if (!checkNull(v, true)) {
             col.values.push(moment(v))
         }
@@ -120,8 +133,8 @@ processDate = function(col){
         col.values = _.sortBy(col.values); // will this cause problems?
 
         // formatted for Rickshaw js input
-        col.timeSeries = _.each(_.uniq(col.values), function(v,i,a){
-            a[i] = {'x': moment(+v.key).unix(), 'y': v.values};
+        col.timeSeries = _.each(_.uniq(col.values), function(v,i,a) {
+            a[i] = {"x": moment(+v.key).unix(), "y": v.values};
         });
 
         col.max = _.last(col.values);
@@ -134,49 +147,49 @@ processDate = function(col){
         // and also make sure the diffs aren't all exactly the next largest interval
 
         col.intervals = {
-            'year': col.max.diff(col.min, 'years') > 0,
-            'month': col.max.diff(col.min, 'months') > 0 && _.some(col.values,
-                function(v,i,a){
-                    if (a[i+1] != undefined){
-                        return v.diff(a[i+1], 'years', true) != v.diff(a[i+1], 'years');
+            "year": col.max.diff(col.min, "years") > 0,
+            "month": col.max.diff(col.min, "months") > 0 && _.some(col.values,
+                function(v,i,a) {
+                    if (a[i+1] != undefined) {
+                        return v.diff(a[i+1], "years", true) != v.diff(a[i+1], "years");
                     } else {
                         return false;
                     }
                 }),
-                'day': col.max.diff(col.min, 'day') > 0 && _.some(col.values,
-                    function(v,i,a){
-                        if (a[i+1] != undefined){
-                            return v.diff(a[i+1], 'months', true) != v.diff(a[i+1], 'months');
+                "day": col.max.diff(col.min, "day") > 0 && _.some(col.values,
+                    function(v,i,a) {
+                        if (a[i+1] != undefined) {
+                            return v.diff(a[i+1], "months", true) != v.diff(a[i+1], "months");
                         } else {
                             return false;
                         }
                     }),
-                    'hour': col.max.diff(col.min, 'hours') > 0 && _.some(col.values,
-                        function(v,i,a){
-                            if (a[i+1] != undefined){
-                                return v.diff(a[i+1], 'days', true) != v.diff(a[i+1], 'days');
+                    "hour": col.max.diff(col.min, "hours") > 0 && _.some(col.values,
+                        function(v,i,a) {
+                            if (a[i+1] != undefined) {
+                                return v.diff(a[i+1], "days", true) != v.diff(a[i+1], "days");
                             } else {
                                 return false;
                             }
                         }),
-                        'minute': col.max.diff(col.min, 'minutes') > 0 && _.some(col.values,
-                            function(v,i,a){
-                                if (a[i+1] != undefined){
-                                    return v.diff(a[i+1], 'hours', true) != v.diff(a[i+1], 'hours');
+                        "minute": col.max.diff(col.min, "minutes") > 0 && _.some(col.values,
+                            function(v,i,a) {
+                                if (a[i+1] != undefined) {
+                                    return v.diff(a[i+1], "hours", true) != v.diff(a[i+1], "hours");
                                 } else {
                                     return false;
                                 }
                             }),
-                            'second': col.max.diff(col.min, 'seconds') > 0 && _.some(col.values,
-                                function(v,i,a){
-                                    if (a[i+1] != undefined){
-                                        return v.diff(a[i+1], 'minutes', true) != v.diff(a[i+1], 'minutes');
+                            "second": col.max.diff(col.min, "seconds") > 0 && _.some(col.values,
+                                function(v,i,a) {
+                                    if (a[i+1] != undefined) {
+                                        return v.diff(a[i+1], "minutes", true) != v.diff(a[i+1], "minutes");
                                     } else {
                                         return false;
                                     }
                                 })
                             };
-                            _.each(col.values, function(v,i,a){
+                            _.each(col.values, function(v,i,a) {
                                 a[i] = checkNull(v, true)? undefined : v.unix();
                             });
 
@@ -185,20 +198,28 @@ processDate = function(col){
     }
 
     // store count of nulls
-    col.nulls = _.reduce(col.orig_values, function(memo, v){
+    col.nulls = _.reduce(col.orig_values, function(memo, v) {
         return checkNull(v, true)? memo + 1 : memo;
     }, 0);
 
     return col;
 }
 
-checkNull = function(value, exclude_empty){
-    return _.isUndefined(value) || _.isNaN(value) || _.isNull(value) || value === 'None'
-    || value === 'null' || value === 'NA' || value === 'N/A'|| value === '#N/A' || (value==='' && exclude_empty) || value == 'undefined';
+checkNull = function(value, excludeEmpty) {
+  return _.isUndefined(value) 
+    || _.isNaN(value) 
+    || _.isNull(value) 
+    || value === "None"
+    || value === "null" 
+    || value === "NA" 
+    || value === "N/A"
+    || value === "#N/A" 
+    || (value === "" && excludeEmpty) 
+    || value == "undefined";
 }
 
 
-roundToPrecision = function(number, places){
+roundToPrecision = function(number, places) {
     var multiplier = Math.pow(10, places);
     return Math.round(number * multiplier) / multiplier;
 }

--- a/server/csv.js
+++ b/server/csv.js
@@ -7,14 +7,14 @@ var DATATYPE_SORT_IDX = {
 };
 
 Meteor.methods({
-    'processCsv': processCsv,
+    "processCsv": processCsv,
 });
 
 function processCsv(csvfile, name){
 
-    // using collectionFS package
+    // Using collectionFS package
     CSV().from.string(csvfile)
-    // need to bind Meteor environment to callbacks in other libraries
+    // Need to bind Meteor environment to callbacks in other libraries
     .to.array(Meteor.bindEnvironment(function(data){
 
         var dataset = {
@@ -24,43 +24,43 @@ function processCsv(csvfile, name){
             "questions": []
         };
 
-        // add to database or replace existing with same name
+        // Add to database or replace existing with same name
         var d_id = Datasets.insert(dataset);
-        console.log('added dataset', name);
+        console.log("Added dataset ", name);
 
-        // convert rows to columns
+        // Convert rows to columns
         var cols = _.zip.apply(_, data);
-        // convert arrays to objects, separate name from values
+        // Convert arrays to objects, separate name from values
         _.each(cols, function(v,i,a){
             a[i] = {
                 "user_id": Meteor.userId(),
                 name: v[0],
                 values: [],
-                'orig_values': _.rest(v),
-                'dataset_id': d_id
+                "orig_values": _.rest(v),
+                "dataset_id": d_id
             };
         });
         
-        // detect the datatype
+        // Detect the datatype
         _.each(cols, function(col) {
             var datatype = detectDataType(col.orig_values);
-            col['datatype'] = datatype[0];
-            col['datatypeIdx'] = DATATYPE_SORT_IDX[datatype[0]];
+            col["datatype"] = datatype[0];
+            col["datatypeIdx"] = DATATYPE_SORT_IDX[datatype[0]];
 
-            // cast numbers and dates before storing
-            if (datatype[0] == 'float'){
+            // Cast numbers and dates before storing
+            if (datatype[0] == "float"){
                 col = processFloat(col);
 
-            } else if (datatype[0] == 'integer') {
+            } else if (datatype[0] == "integer") {
                 col = processInt(col);
 
-            } else if (datatype[0] == 'string') {
+            } else if (datatype[0] == "string") {
                 col = processString(col);
 
-            } else if (datatype[0] == 'date') {
+            } else if (datatype[0] == "date") {
                 col = processDate(col);
 
-            } else if (datatype[0] == 'time') {
+            } else if (datatype[0] == "time") {
                 col = processTime(col);
             }
 
@@ -74,10 +74,10 @@ function processCsv(csvfile, name){
 }
 
 function checkIsTime(item) {
-  var t = _.clone(item).match(/(\d\d\d\d)|(\d\d:\d\d)|(\d\d:\d\d:\d\d) ?(am|pm)?/i);
+  var t = item.match(/(\d\d\d\d)|(\d\d:\d\d)|(\d\d:\d\d:\d\d) ?(am|pm)?/i);
   if (t != null) {
-      t = t.replace(":", "");
-      var h = parseInt(t.substr(0,2))
+      var t = item.replace(":", "")
+        , h = parseInt(t.substr(0,2))
         , validHours = (h >= 0 && h <= 24)
         , m = parseInt(t.substr(2,4))
         , validMinutes = (m >= 0 && m <= 60)
@@ -103,27 +103,51 @@ var MONTHS = [
   "december", "dec"
 ];
 
-var TIMEZONE_ABBRS = ["a", "acdt", "acst", "act", "acwst", "adst", "adt", "aedt", "aest", "aet", "aft", "akdt", "akst", "almt", "amdt", "amst", "amt", "anast", "anat", "aoe", "aqtt", "art", "asia", "ast", "at", "awdt", "awst", "azodt", "azost", "azot", "azst", "azt", "b", "bdst", "bdt", "bnt", "bot", "brst", "brt", "bst", "bt", "btt", "c", "cast", "cat", "cct", "cdst", "cdt", "cedt", "cest", "cet", "chadt", "chast", "chot", "chst", "chut", "ckt", "cldt", "clst", "clt", "cot", "cst", "ct", "cvt", "cxt", "d", "davt", "ddut", "e", "eadt", "easst", "east", "eat", "ecst", "ect", "edst", "edt", "eedt", "eest", "eet", "efate", "egst", "egt", "est", "et", "f", "fet", "fjdt", "fjst", "fjt", "fkdt", "fkst", "fkt", "fnt", "g", "galt", "gamt", "get", "gft", "gilt", "gmt", "gst", "gt", "gyt", "h", "haa", "hac", "hadt", "hae", "hap", "har", "hast", "hat", "hdt", "hkt", "hlv", "hna", "hnc", "hne", "hnp", "hnr", "hnt", "hovt", "hst", "i", "ict", "idt", "iot", "irdt", "irkst", "irkt", "irst", "ist", "it", "jst", "k", "kgt", "kit", "kost", "krast", "krat", "kst", "kt", "kuyt", "l", "lhdt", "lhst", "lint", "m", "magst", "magt", "mart", "mawt", "mck", "mdst", "mdt", "mesz", "mez", "mht", "mmt", "msd", "msk", "mst", "mt", "mut", "mvt", "myt", "n", "nacdt", "nacst", "naedt", "naest", "namdt", "namst", "napdt", "napst", "nct", "ndt", "nft", "novst", "novt", "npt", "nrt", "nst", "nut", "nzdt", "nzst", "o", "oesz", "oez", "omsst", "omst", "orat", "p", "pdst", "pdt", "pet", "petst", "pett", "pgt", "phot", "pht", "pkt", "pmdt", "pmst", "pont", "pst", "pt", "pwt", "pyst", "pyt", "q", "qyzt", "r", "ret", "rott", "s", "sakt", "samst", "samt", "sast", "sbt", "sct", "sgt", "sret", "srt", "sst", "st", "syot", "t", "taht", "tft", "tjt", "tkt", "tlt", "tmt", "tot", "tvt", "u", "ulat", "utc", "uyst", "uyt", "uzt", "v", "vet", "vlast", "vlat", "vost", "vut", "w", "wakt", "warst", "wast", "wat", "wdt", "wedt", "wesz", "wet", "wez", "wft", "wgst", "wgt", "wib", "wit", "wita", "wst", "wt", "x", "y", "yakst", "yakt", "yapt", "yekst", "yekt", "z"];
+var TIMEZONES = ["a", "acdt", "acst", "act", "acwst", "adst", "adt", "aedt", "aest", "aet", "aft", "akdt", "akst", "almt", "amdt", "amst", "amt", "anast", "anat", "aoe", "aqtt", "art", "asia", "ast", "at", "awdt", "awst", "azodt", "azost", "azot", "azst", "azt", "b", "bdst", "bdt", "bnt", "bot", "brst", "brt", "bst", "bt", "btt", "c", "cast", "cat", "cct", "cdst", "cdt", "cedt", "cest", "cet", "chadt", "chast", "chot", "chst", "chut", "ckt", "cldt", "clst", "clt", "cot", "cst", "ct", "cvt", "cxt", "d", "davt", "ddut", "e", "eadt", "easst", "east", "eat", "ecst", "ect", "edst", "edt", "eedt", "eest", "eet", "efate", "egst", "egt", "est", "et", "f", "fet", "fjdt", "fjst", "fjt", "fkdt", "fkst", "fkt", "fnt", "g", "galt", "gamt", "get", "gft", "gilt", "gmt", "gst", "gt", "gyt", "h", "haa", "hac", "hadt", "hae", "hap", "har", "hast", "hat", "hdt", "hkt", "hlv", "hna", "hnc", "hne", "hnp", "hnr", "hnt", "hovt", "hst", "i", "ict", "idt", "iot", "irdt", "irkst", "irkt", "irst", "ist", "it", "jst", "k", "kgt", "kit", "kost", "krast", "krat", "kst", "kt", "kuyt", "l", "lhdt", "lhst", "lint", "m", "magst", "magt", "mart", "mawt", "mck", "mdst", "mdt", "mesz", "mez", "mht", "mmt", "msd", "msk", "mst", "mt", "mut", "mvt", "myt", "n", "nacdt", "nacst", "naedt", "naest", "namdt", "namst", "napdt", "napst", "nct", "ndt", "nft", "novst", "novt", "npt", "nrt", "nst", "nut", "nzdt", "nzst", "o", "oesz", "oez", "omsst", "omst", "orat", "p", "pdst", "pdt", "pet", "petst", "pett", "pgt", "phot", "pht", "pkt", "pmdt", "pmst", "pont", "pst", "pt", "pwt", "pyst", "pyt", "q", "qyzt", "r", "ret", "rott", "s", "sakt", "samst", "samt", "sast", "sbt", "sct", "sgt", "sret", "srt", "sst", "st", "syot", "t", "taht", "tft", "tjt", "tkt", "tlt", "tmt", "tot", "tvt", "u", "ulat", "utc", "uyst", "uyt", "uzt", "v", "vet", "vlast", "vlat", "vost", "vut", "w", "wakt", "warst", "wast", "wat", "wdt", "wedt", "wesz", "wet", "wez", "wft", "wgst", "wgt", "wib", "wit", "wita", "wst", "wt", "x", "y", "yakst", "yakt", "yapt", "yekst", "yekt", "z"];
 
-function checkIsDate(item) {
-  var d = _.clone(item).match(/[a-z]/i)
-  if (d != null) {
-    // Make sure letters are only months or timezones
-    var words = [];
-    // Iterate over characters, collecting words.
-    // For each word, check that it is in one of the above two lists.
-    // If not, return false
-  }
-  // Otherwise check using moment.js
+function isLetter(str) {
+  return str.length === 1 && str.match(/[a-z]/i);
 }
 
-function detectDataType(items {
+function checkIsDate(item) {
+  var d = item.toLowerCase().match(/[a-z]/i)
+  if (d != null) {
+    
+    // Make sure letters are only months or timezones
+    var words = []
+      , chars = item.toLowerCase().split("")
+      , word = "";
+    
+    // Iterate over characters, collecting words
+    _.each(chars, function(c) {
+      if (isLetter(c)) {
+        word = word + c;
+      } else {
+        if (word.length > 0) {
+          words.push(word);
+          word = "";
+        }
+      }
+    });        
+
+    // For each word, check that it is in one of the above two lists
+    _.each(words, function(w) {
+      // If not, return false
+      if (MONTHS.indexOf(w) == -1 && TIMEZONES.indexOf(w) == -1) return false;
+    });
+  }
+
+  // Otherwise check using moment.js
+  return moment(item).isValid(); 
+}
+
+function detectDataType(column) {
   
   var validItems = _.filter(items, function(item, idx) {
-    return !checkNull(item);
+    return !checkNull(item, true);
   })
 
-  var counts = {integer: 0, float: 0, date: 0, number: 0, string: 0, time: 0}
+  var counts = {integer: 0, float: 0, date: 0, time: 0}
     , isInteger = true
     , isFloat = true
     , isTime = true
@@ -131,23 +155,23 @@ function detectDataType(items {
 
   _.each(validItems, function(item) {
 
-    // Check integer.
-    var n = _.clone(item).replace(",", "").match(/^-?[\d]+(.[0]+)?$/);
+    // Check integer
+    var n = item.replace(",", "").match(/^-?(?:[1-9][\d]*)(?:.[0]+)?$/);
     if (n == null) {
       isInteger = false;
     } else {
       counts.integer += 1;
     }
 
-    // Check float.
-    var f = _.clone(item).replace(",", "").match(/^-?[\d]*(.[\d]+)?$/);
+    // Check float
+    var f = item.replace(",", "").match(/^-?(?:(?:[1-9][\d]*)?|0?)(?:\.[\d]+)?$/);
     if (f == null) {
       isFloat = false;
     } else {
       counts.float += 1;
     }
 
-    // Check time.
+    // Check time
     var t = checkIsTime(item);
     if (!t) {
       isTime = false;
@@ -155,116 +179,34 @@ function detectDataType(items {
       counts.time += 1;
     }
 
-    // Check date.
+    // Check date
     var d = checkIsDate(item);
     if (!d) {
       isDate = false;
     } else {
       counts.date += 1;
     }
-    
-  }
+  });
 
-  // Default to string.
+  // Default to string
   var result = ["string", counts];
 
   if (isInteger) {
-    result = "integer";
+    result[0] = "integer";
     return result;
   }
   if (isFloat) {
-    result = "float";
+    result[0] = "float";
     return result;
   }
   if (isTime) {
-    result = "time";
+    result[0] = "time";
     return result;
   }
   if (isDate) {
-    result = "date";
+    result[0] = "date";
     return result;
   }
   return result;
   
-}
-
-function detectDataType(items){
-    // remove nulls
-    var new_items = _.filter(items, function(item, index) {
-        return !checkNull(item);
-    });
-
-    // randomize the values
-    var sample = _.sample(new_items, new_items.length);
-
-    // initialize vote tallies
-    var counts = {integer: 0, float: 0, date: 0, number: 0, string: 0, time: 0};
-
-    _.each(new_items, function(item) {
-
-        // check for alpha and punct
-        var chars = _.clone(item).toLowerCase().match(/[a-z$^{[(|)*+?\\]/i);
-        if (chars !== null) {
-            // vote for string
-            counts.string += 1;
-        }
-
-        var n = Number(item);
-        if (!_.isNaN(n) && chars === null){
-            // vote for number
-            counts.number += 1;
-
-            // more specific number types
-            if (item.indexOf('.') > -1){
-                var f = parseFloat(item);
-                // vote for float
-                counts.float += 1;
-            } else {
-                var integer = parseInt(item);
-                // vote for integer
-                counts.integer += 1;
-            }
-        }
-
-        // requires moment.js package
-        if (moment(item).isValid()) {
-            // vote for date
-            counts['date'] += 1;
-        }
-
-        time = item.match(/(\d:[0-5]\d)|([0-1]\d:[0-5]\d)/i);
-        if (time != null) {
-            counts.time += 1;
-        }
-    });
-
-    var metrics = _.map(counts, function(value, key) {
-        return {name: key, value: value};
-    });
-
-    var max = _.max(metrics, function(metric) {
-        return metric.value;
-    });
-
-    var result = ['string', counts];
-
-    // if no value gets a majority, default to string
-    if (max.value > new_items.length / 2){
-
-        // if any members aren't numbers, it's a string
-        if ((max.name === 'number' || max.name === 'integer' || max.name==='float') && counts.string === 0){
-
-            // if anything can be parsed as a float, it's a float
-            if (counts.float > 0)
-                result[0] = 'float';
-            else
-                result[0] = 'integer';
-        }
-        else if (max.name === 'date')
-            result[0] = 'date';
-        else if (max.name == 'time')
-            result[0] = 'time';
-    }
-
-    return result;
 }

--- a/server/csv.js
+++ b/server/csv.js
@@ -141,7 +141,7 @@ function checkIsDate(item) {
   return moment(item).isValid(); 
 }
 
-function detectDataType(column) {
+function detectDataType(items) {
   
   var validItems = _.filter(items, function(item, idx) {
     return !checkNull(item, true);

--- a/server/csv.js
+++ b/server/csv.js
@@ -73,7 +73,121 @@ function processCsv(csvfile, name){
     }));
 }
 
-// utility functions for processor
+function checkIsTime(item) {
+  var t = _.clone(item).match(/(\d\d\d\d)|(\d\d:\d\d)|(\d\d:\d\d:\d\d) ?(am|pm)?/i);
+  if (t != null) {
+      t = t.replace(":", "");
+      var h = parseInt(t.substr(0,2))
+        , validHours = (h >= 0 && h <= 24)
+        , m = parseInt(t.substr(2,4))
+        , validMinutes = (m >= 0 && m <= 60)
+        , s = parseInt(t.substr(4,6))
+        , validSeconds = ((_.isNaN(s)) || (s >= 0 && s <= 60));
+      if (validHours && validMinutes && validSeconds) return true;
+      return false;
+  }
+  return false;
+}
+
+var MONTHS = [
+  "january", "jan",
+  "february", "feb",
+  "march", "mar",
+  "april", "apr",
+  "june", "jun",
+  "july", "jul",
+  "august", "aug",
+  "september", "sept", "sep",
+  "october", "oct",
+  "november", "nov",
+  "december", "dec"
+];
+
+var TIMEZONE_ABBRS = ["a", "acdt", "acst", "act", "acwst", "adst", "adt", "aedt", "aest", "aet", "aft", "akdt", "akst", "almt", "amdt", "amst", "amt", "anast", "anat", "aoe", "aqtt", "art", "asia", "ast", "at", "awdt", "awst", "azodt", "azost", "azot", "azst", "azt", "b", "bdst", "bdt", "bnt", "bot", "brst", "brt", "bst", "bt", "btt", "c", "cast", "cat", "cct", "cdst", "cdt", "cedt", "cest", "cet", "chadt", "chast", "chot", "chst", "chut", "ckt", "cldt", "clst", "clt", "cot", "cst", "ct", "cvt", "cxt", "d", "davt", "ddut", "e", "eadt", "easst", "east", "eat", "ecst", "ect", "edst", "edt", "eedt", "eest", "eet", "efate", "egst", "egt", "est", "et", "f", "fet", "fjdt", "fjst", "fjt", "fkdt", "fkst", "fkt", "fnt", "g", "galt", "gamt", "get", "gft", "gilt", "gmt", "gst", "gt", "gyt", "h", "haa", "hac", "hadt", "hae", "hap", "har", "hast", "hat", "hdt", "hkt", "hlv", "hna", "hnc", "hne", "hnp", "hnr", "hnt", "hovt", "hst", "i", "ict", "idt", "iot", "irdt", "irkst", "irkt", "irst", "ist", "it", "jst", "k", "kgt", "kit", "kost", "krast", "krat", "kst", "kt", "kuyt", "l", "lhdt", "lhst", "lint", "m", "magst", "magt", "mart", "mawt", "mck", "mdst", "mdt", "mesz", "mez", "mht", "mmt", "msd", "msk", "mst", "mt", "mut", "mvt", "myt", "n", "nacdt", "nacst", "naedt", "naest", "namdt", "namst", "napdt", "napst", "nct", "ndt", "nft", "novst", "novt", "npt", "nrt", "nst", "nut", "nzdt", "nzst", "o", "oesz", "oez", "omsst", "omst", "orat", "p", "pdst", "pdt", "pet", "petst", "pett", "pgt", "phot", "pht", "pkt", "pmdt", "pmst", "pont", "pst", "pt", "pwt", "pyst", "pyt", "q", "qyzt", "r", "ret", "rott", "s", "sakt", "samst", "samt", "sast", "sbt", "sct", "sgt", "sret", "srt", "sst", "st", "syot", "t", "taht", "tft", "tjt", "tkt", "tlt", "tmt", "tot", "tvt", "u", "ulat", "utc", "uyst", "uyt", "uzt", "v", "vet", "vlast", "vlat", "vost", "vut", "w", "wakt", "warst", "wast", "wat", "wdt", "wedt", "wesz", "wet", "wez", "wft", "wgst", "wgt", "wib", "wit", "wita", "wst", "wt", "x", "y", "yakst", "yakt", "yapt", "yekst", "yekt", "z"];
+
+function checkIsDate(item) {
+  var d = _.clone(item).match(/[a-z]/i)
+  if (d != null) {
+    // Make sure letters are only months or timezones
+    var words = [];
+    // Iterate over characters, collecting words.
+    // For each word, check that it is in one of the above two lists.
+    // If not, return false
+  }
+  // Otherwise check using moment.js
+}
+
+function detectDataType(items {
+  
+  var validItems = _.filter(items, function(item, idx) {
+    return !checkNull(item);
+  })
+
+  var counts = {integer: 0, float: 0, date: 0, number: 0, string: 0, time: 0}
+    , isInteger = true
+    , isFloat = true
+    , isTime = true
+    , isDate = true;
+
+  _.each(validItems, function(item) {
+
+    // Check integer.
+    var n = _.clone(item).replace(",", "").match(/^-?[\d]+(.[0]+)?$/);
+    if (n == null) {
+      isInteger = false;
+    } else {
+      counts.integer += 1;
+    }
+
+    // Check float.
+    var f = _.clone(item).replace(",", "").match(/^-?[\d]*(.[\d]+)?$/);
+    if (f == null) {
+      isFloat = false;
+    } else {
+      counts.float += 1;
+    }
+
+    // Check time.
+    var t = checkIsTime(item);
+    if (!t) {
+      isTime = false;
+    } else {
+      counts.time += 1;
+    }
+
+    // Check date.
+    var d = checkIsDate(item);
+    if (!d) {
+      isDate = false;
+    } else {
+      counts.date += 1;
+    }
+    
+  }
+
+  // Default to string.
+  var result = ["string", counts];
+
+  if (isInteger) {
+    result = "integer";
+    return result;
+  }
+  if (isFloat) {
+    result = "float";
+    return result;
+  }
+  if (isTime) {
+    result = "time";
+    return result;
+  }
+  if (isDate) {
+    result = "date";
+    return result;
+  }
+  return result;
+  
+}
+
 function detectDataType(items){
     // remove nulls
     var new_items = _.filter(items, function(item, index) {


### PR DESCRIPTION
Closes #52 

Note that there is still one remaining sort of bug, but it's more of a data bug: the FAA Wildlife Strike dataset has one value that is "1370" in the **TIME** column that causes it to render as a date instead of a time. For example:

```
salspaugh@vagabond:DataFramer> python scripts/print-column-values.py -f data/faa-wildlife-strike-clean.csv -c TIME | grep 1370
1370
```

It's hard to spot in the graph ... I'm wondering how to handle this sort of bug since we want to be able for people to spot things like this. Something to talk about when we meet?