### PR TITLE
Re-sort charts when the datatype of a chart is changed

### DIFF
--- a/client/controllers.js
+++ b/client/controllers.js
@@ -389,37 +389,47 @@ function($scope, $state, $window, $stateParams, $meteorSubscribe, $meteorCollect
            [{'name': 'Keep', 'answerable': true },
             {'name': 'Undecided' , 'answerable': null },
             {'name': 'Reject', 'answerable': false }];
+            
+    var DATATYPE_SORT_IDX = {
+      "string": 0,
+      "integer": 1,
+      "float": 2,
+      "date": 3,
+      "time": 4
+    };
 
-    $scope.changeType = changeType;
+    $scope.changeType = function changeType(col, type) {
+        col.datatype = type;
+        col.datatypeIdx = DATATYPE_SORT_IDX[type];
+        col.values = [];
+        scope = this.$parent
+        switch (type) {
+            case "string":
+                col = processString(col);
+                scope.renderChart(scope);
+                break;
+            case "date":
+                col = processDate(col);
+                scope.renderChart(scope);
+                break;
+            case "float":
+                col = processFloat(col);
+                scope.renderChart(scope);
+                break;
+            case "integer":
+                col = processInt(col);
+                scope.renderChart(scope);
+                break;
+            case "time":
+                col = processTime(col);
+                scope.renderChart(scope);
+                break;
+            default:
+                break;
+            }
+        // Reload the page
+        $state.go($state.current, {}, {reload: true}); 
+    }
 
 }]);
 
-function changeType(col, type){
-    col.datatype = type;
-    col.values = [];
-    scope = this.$parent
-    switch (type) {
-        case "string":
-            col = processString(col);
-            scope.renderChart(scope);
-            break;
-        case "date":
-            col = processDate(col);
-            scope.renderChart(scope);
-            break;
-        case "float":
-            col = processFloat(col);
-            scope.renderChart(scope);
-            break;
-        case "integer":
-            col = processInt(col);
-            scope.renderChart(scope);
-            break;
-        case "time":
-            col = processTime(col);
-            scope.renderChart(scope);
-            break;
-        default:
-            break;
-        }
-}

--- a/client/states.js
+++ b/client/states.js
@@ -1,6 +1,5 @@
 angular.module('dataFramer').config(['$urlRouterProvider', '$stateProvider', '$locationProvider',
 function($urlRouterProvider, $stateProvider, $locationProvider){
-    // debugger;
     $locationProvider.html5Mode(true);
 
     $stateProvider
@@ -11,7 +10,7 @@ function($urlRouterProvider, $stateProvider, $locationProvider){
                     templateUrl: 'client/templates/nav-bar.tpl',
                     controller: 'NavBarController'
                 },
-                // in this state, all the navigation elements should be disabled
+                // In this state, all the navigation elements should be disabled
                 main: {
                     templateUrl: 'client/templates/dataset-index.tpl',
                     controller: 'DatasetIndexController'
@@ -21,7 +20,7 @@ function($urlRouterProvider, $stateProvider, $locationProvider){
         .state('dataset', {
             url: '/dataset/:datasetId',
             views: {
-                // this will be inherited by all the other dataset.x states
+                // This will be inherited by all the other dataset.x states
                 navBar: {
                     templateUrl: 'client/templates/nav-bar.tpl',
                     controller: 'NavBarController'
@@ -31,7 +30,7 @@ function($urlRouterProvider, $stateProvider, $locationProvider){
         .state('dataset.questionIndex', {
             url: '/questions',
             views: {
-                // the list of questions - separate from charts
+                // The list of questions - separate from charts
                 'main@': {
                     templateUrl: 'client/templates/question-index.tpl',
                     controller: 'QuestionIndexController'
@@ -41,7 +40,7 @@ function($urlRouterProvider, $stateProvider, $locationProvider){
         .state('dataset.questionSingle', {
             url: '/questions/:questionId',
             views: {
-                // a single question view - not that different than before
+                // A single question view
                 'main@': {
                     templateUrl: 'client/templates/question-single.tpl',
                     controller: 'QuestionSingleController'
@@ -51,23 +50,12 @@ function($urlRouterProvider, $stateProvider, $locationProvider){
         .state('dataset.charts', {
             url: '/charts',
             views: {
-                // all the charts, like before
+                // All the charts
                 "main@": {
                     templateUrl: 'client/templates/charts.tpl',
                     controller: 'ChartsController'
                 }
             }
         })
-        // .state('dataset.addToQuestionModal', {
-        //     url: '/charts',
-        //     views: {
-        //         // the list of questions - separate from charts
-        //         'main@': {
-        //             templateUrl: 'client/templates/add-question.tpl',
-        //             controller: 'AddToQuestionController'
-        //         }
-        //     }
-        // })
-        // ;
 
 }]);


### PR DESCRIPTION
So charts remain in sorted order. The only bad thing is that as far as I can tell it's necessary to reload the page to do this, which is a bit slow -- thoughts?

Closes #50 